### PR TITLE
Update test.ts

### DIFF
--- a/angular-electron/src/test.ts
+++ b/angular-electron/src/test.ts
@@ -1,11 +1,6 @@
-// This file is required by karma.conf.js and loads recursively all the .spec and framework files
-
 import 'zone.js/dist/zone-testing';
-import { getTestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: {
   context(path: string, deep?: boolean, filter?: RegExp): {
@@ -14,12 +9,19 @@ declare const require: {
   };
 };
 
-// First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+const testBedConfig: TestModuleMetadata = {
+  imports: [BrowserDynamicTestingModule],
+  providers: [],
+  declarations: [],
+  schemas: []
+};
+
+TestBed.initTestEnvironment(
+  [BrowserDynamicTestingModule],
+  platformBrowserDynamicTestingModule()
 );
-// Then we find all the tests.
+
 const context = require.context('./', true, /\.spec\.ts$/);
-// And load the modules.
-context.keys().map(context);
+context.keys().forEach((key: string) => {
+  context(key);
+});


### PR DESCRIPTION
Use ES6 imports instead of the require() function to load the testing dependencies: Use the configureTestBed() function instead of the getTestBed().initTestEnvironment() method to configure the testing environment. configureTestBed() is a convenient method that sets up TestBed and the necessary Angular modules with a single call: