### PR TITLE
Update app.po.ts

### DIFF
--- a/angular-electron/e2e/src/app.po.ts
+++ b/angular-electron/e2e/src/app.po.ts
@@ -1,8 +1,8 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
-    return browser.get(browser.baseUrl) as Promise<unknown>;
+  navigateTo(): Promise<void> {
+    return browser.get(browser.baseUrl) as Promise<void>;
   }
 
   getTitleText(): Promise<string> {


### PR DESCRIPTION
The Promise<unknown> return type in the navigateTo() method can be changed to Promise<void> since the method doesn't return anything. This change makes the code more explicit and easier to understand.